### PR TITLE
Fixed IPv8 import

### DIFF
--- a/anydex/__init__.py
+++ b/anydex/__init__.py
@@ -1,6 +1,9 @@
 import os
 import sys
 
-# Make sure IPv8 can be imported
-dir_path = os.path.dirname(os.path.realpath(__file__))
-sys.path.insert(0, os.path.join(dir_path, "..", "pyipv8"))
+try:
+    import ipv8
+except ImportError:
+    # Make sure IPv8 can be imported
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    sys.path.insert(0, os.path.join(dir_path, "..", "pyipv8"))


### PR DESCRIPTION
Not adding the Anydex IPv8 version to the paths if it can already be imported, as is usually the case when running Tribler.