### PR TITLE
Fixed an error where trading_peer was not set in a transaction

### DIFF
--- a/anydex/core/community.py
+++ b/anydex/core/community.py
@@ -403,7 +403,7 @@ class MarketCommunity(Community, BlockListener):
             chr(MSG_PK_RESPONSE): self.received_trader_pk_response
         })
 
-        self.logger.info("Market community initialized with mid %s", hexlify(self.mid))
+        self.logger.info("Market community initialized with mid %s", hexlify(self.mid).decode())
 
     def initialize_trustchain(self):
         market_block_types = [b'ask', b'bid', b'cancel_order', b'tx_init', b'tx_payment', b'tx_done']

--- a/anydex/core/community.py
+++ b/anydex/core/community.py
@@ -701,6 +701,9 @@ class MarketCommunity(Community, BlockListener):
                 self.logger.warning("Could not find transaction associated for signed payment block %s", block)
                 return
 
+            if not transaction.trading_peer:
+                transaction.trading_peer = self.get_peer_from_mid(bytes(transaction.partner_order_id.trader_id))
+
             if transaction.is_payment_complete():
                 order = self.order_manager.order_repository.find_by_id(transaction.order_id)
 


### PR DESCRIPTION
When using a non-memory database, we fetch the transaction every time from the database. This will reset the `trading_peer` attribute, which is not persisted in the database. However, it seems that it was not reinitialised when we process an incoming payment.

Also fixed a minor error in a logging statement.

I tested these changes with a validation experiment using a real sqlite database, see [here](https://jenkins-ci.tribler.org/job/AnyDex/job/validation_experiment_market/).